### PR TITLE
fix: typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       {
         "command": "slidev.preview-refresh",
         "category": "Slidev",
-        "title": "Preivew Refresh",
+        "title": "Preview Refresh",
         "icon": "$(refresh)"
       },
       {


### PR DESCRIPTION
Fixes a small typo:
![image showing the VSCode command "preview refresh" with a typo](https://user-images.githubusercontent.com/20427094/120066136-57b33100-c075-11eb-8eb4-20b8c04b703e.png)
